### PR TITLE
feat : 공통 버튼 컴포넌트

### DIFF
--- a/src/app/(contents)/test11/page.tsx
+++ b/src/app/(contents)/test11/page.tsx
@@ -1,11 +1,21 @@
 'use client';
 
 import NavigationBar from '@/components/navigationBar';
+import FilledButton from '@/components/button/filledButton';
+import NoFilledButton from '@/components/button/noFilledButton';
+import DisabledButton from '@/components/button/disabledButton';
 import { useState } from 'react';
 
 export default function test11() {
   const [isAuthorized, setIsAuthorized] = useState<boolean>(true);
   const [isNotification, setIsNotification] = useState<boolean>(false);
 
-  return <NavigationBar isAuthorized={isAuthorized} isNotification={isNotification} />;
+  return (
+    <div className=" flex-col">
+      <NavigationBar isAuthorized={isAuthorized} isNotification={isNotification} />
+      <FilledButton width={350} name="로그인 하기" />
+      <NoFilledButton width={350} name="로그인 하기" />
+      <DisabledButton width={350} name="신청불가" />
+    </div>
+  );
 }

--- a/src/components/button/disabledButton/index.tsx
+++ b/src/components/button/disabledButton/index.tsx
@@ -1,0 +1,17 @@
+interface DisabledButtonProps {
+  width: number;
+  name: string;
+}
+
+const DisabledButton = ({ width, name }: DisabledButtonProps) => {
+  return (
+    <button
+      style={{ width: `${width}px` }}
+      className={`bg-gray40 h-[32px] md:h-[37px] lg:h-[48px]  rounded-[6px] text-white font-bold text-[12px] md:text-[14px] lg:text-[16px] inline-flex py-[14px] justify-center items-center gap-[8px]`}
+    >
+      {name}
+    </button>
+  );
+};
+
+export default DisabledButton;

--- a/src/components/button/filledButton/index.tsx
+++ b/src/components/button/filledButton/index.tsx
@@ -1,0 +1,17 @@
+interface FilledButtonProps {
+  width: number;
+  name: string;
+}
+
+const FilledButton = ({ width, name }: FilledButtonProps) => {
+  return (
+    <button
+      style={{ width: `${width}px` }}
+      className={`bg-[#EA3C12] h-[32px] md:h-[37px] lg:h-[48px]  rounded-[6px] text-white font-bold text-[12px] md:text-[14px] lg:text-[16px] inline-flex py-[14px] justify-center items-center gap-[8px]`}
+    >
+      {name}
+    </button>
+  );
+};
+
+export default FilledButton;

--- a/src/components/button/noFilledButton/index.tsx
+++ b/src/components/button/noFilledButton/index.tsx
@@ -1,0 +1,17 @@
+interface NoFilledButtonProps {
+  width: number;
+  name: string;
+}
+
+const NoFilledButton = ({ width, name }: NoFilledButtonProps) => {
+  return (
+    <button
+      style={{ width: `${width}px` }}
+      className={`bg-white border-[#EA3C12] border  h-[32px] md:h-[37px] lg:h-[48px]  rounded-[6px] text-[#EA3C12] font-bold text-[12px] md:text-[14px] lg:text-[16px] inline-flex py-[14px] justify-center items-center gap-[8px]`}
+    >
+      {name}
+    </button>
+  );
+};
+
+export default NoFilledButton;


### PR DESCRIPTION
## 💻 작업 내용

- 공통 버튼 컴포넌트

## 🖼️ 스크린샷

![image](https://github.com/user-attachments/assets/2cec5760-db37-4686-9686-1c1a5b9b9258)


## 🚨 관련 이슈 및 참고 사항

- 피그마에서 주어지는 로그인 하기 버튼과 신청불가 버튼은 pc tablet mobile 사이즈 별로 나누어져있으나 다른 페이지들의 버튼들을 보았을때 제각각 사이즈가 달라 사이즈를 props로 입력받도록 일단 이렇게 구현해주었고 
또한 반응형에서의 사이즈도 제각각 달라 이에 대해서 고려를 해보아야한다. (컴포넌트를 사용할것인지 아니면 각 페이지마다 버튼을 따로 만들어야할지)
