### PR TITLE
Refactor : 내 가게 , 내 프로필 페이지 리다이렉션 리팩토링

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,7 @@ const nextConfig = {
         hostname: 'bootcamp-project-api.s3.ap-northeast-2.amazonaws.com',
       },
     ],
+    formats: ['image/avif', 'image/webp'], // AVIF 우선 적용
   },
 };
 

--- a/src/app/(contents)/myshop/page.tsx
+++ b/src/app/(contents)/myshop/page.tsx
@@ -1,15 +1,6 @@
 import ShopDetailContainer from '@/components/myInfoComponents/shopDetailContainer';
-import { redirect } from 'next/navigation';
-import { cookies } from 'next/headers';
 
 export default async function myShop() {
-  const cookieStore = cookies();
-  const shopId = cookieStore.get('shopId')?.value;
-
-  if (shopId) {
-    redirect(`/myshop/${shopId}`);
-  }
-
   return (
     <div className="flex flex-col">
       <ShopDetailContainer />

--- a/src/app/(contents)/myshop/page.tsx
+++ b/src/app/(contents)/myshop/page.tsx
@@ -1,9 +1,0 @@
-import ShopDetailContainer from '@/components/myInfoComponents/shopDetailContainer';
-
-export default async function myShop() {
-  return (
-    <div className="flex flex-col">
-      <ShopDetailContainer />
-    </div>
-  );
-}

--- a/src/components/myInfoComponents/manageMyShopInfo/shopImage/index.tsx
+++ b/src/components/myInfoComponents/manageMyShopInfo/shopImage/index.tsx
@@ -40,7 +40,7 @@ const ShopImage = () => {
           <Image
             src={shopData.imageUrl}
             alt={`${shopData.imageUrl} 이미지`}
-            sizes="(min-width: 1440px) 100vw, (min-width: 744px) 50vw, 33vw"
+            sizes="(min-width: 1810px) 80vw, (min-width: 1440px) 70vw, (min-width: 744px) 50vw, 33vw"
             fill
             style={{ objectFit: 'cover' }}
             className="rounded-[12px]"

--- a/src/components/myInfoComponents/myPostInfo/index.tsx
+++ b/src/components/myInfoComponents/myPostInfo/index.tsx
@@ -30,7 +30,7 @@ const MyPostInfo: React.FC<MyPostInfoProps> = ({
           <Image
             src={cachedShopData?.item.imageUrl}
             alt={`${cachedShopData?.item.imageUrl} 이미지`}
-            sizes="(min-width: 1440px) 100vw, (min-width: 744px) 50vw, 33vw"
+            sizes="(min-width: 1810px) 80vw, (min-width: 1440px) 70vw, (min-width: 744px) 50vw, 33vw"
             fill
             style={{ objectFit: 'cover' }}
             className="rounded-[12px]"

--- a/src/components/myInfoComponents/myShopInfo/index.tsx
+++ b/src/components/myInfoComponents/myShopInfo/index.tsx
@@ -35,7 +35,7 @@ const MyShopInfo = ({ shopInfo, shopId }: MyShopInfoProps) => {
         <Image
           src={shopInfo.imageUrl}
           alt={`${shopInfo.imageUrl} 이미지`}
-          sizes="(min-width: 1440px) 100vw, (min-width: 744px) 50vw, 33vw"
+          sizes="(min-width: 1810px) 80vw, (min-width: 1440px) 70vw, (min-width: 744px) 50vw, 33vw"
           fill
           style={{ objectFit: 'cover' }}
           className="rounded-[12px]"

--- a/src/components/noticeComponents/noticeList/index.tsx
+++ b/src/components/noticeComponents/noticeList/index.tsx
@@ -45,7 +45,7 @@ export default function NoticeList({ noticeData }: { noticeData: NoticeData }) {
           <Image
             src={processedShopData?.imageUrl || '/default-image.jpg'}
             alt={`${processedShopData?.name} 이미지`}
-            sizes="(min-width: 1440px) 100vw, (min-width: 744px) 50vw, 33vw"
+            sizes="(min-width: 1810px) 80vw, (min-width: 1440px) 70vw, (min-width: 744px) 50vw, 33vw"
             fill
             style={{ objectFit: 'cover' }}
             className="rounded-[12px]"

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -20,6 +20,7 @@ export async function middleware(req: NextRequest) {
   const cookieToken = req.cookies.get('token');
   const cookieType = req.cookies.get('myType');
   const cookieShopId = req.cookies.get('shopId');
+  const cookieUserId = req.cookies.get('userId');
 
   let token;
   let type;
@@ -32,11 +33,21 @@ export async function middleware(req: NextRequest) {
 
   const shopIdFromPath = pathname.startsWith('/myshop') ? pathname.split('/myshop/')[1] : null;
 
-  // Check if shopId in the URL matches the cookieShopId
   if (pathname.startsWith('/myshop') && cookieShopId) {
     const cookieShopIdValue = cookieShopId.value;
     if (shopIdFromPath !== cookieShopIdValue) {
       return NextResponse.redirect(new URL(`/myshop/${cookieShopIdValue}`, req.url));
+    }
+  }
+
+  const userIdIdFromPath = pathname.startsWith('/myprofile')
+    ? pathname.split('/myprofile/')[1]
+    : null;
+
+  if (pathname.startsWith('/myprofile') && cookieUserId) {
+    const cookieUserIdValue = cookieUserId.value;
+    if (userIdIdFromPath !== cookieUserIdValue) {
+      return NextResponse.redirect(new URL(`/myprofile/${cookieUserIdValue}`, req.url));
     }
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,9 +17,9 @@ export const config = {
 
 export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
-  console.log(pathname);
   const cookieToken = req.cookies.get('token');
   const cookieType = req.cookies.get('myType');
+  const cookieShopId = req.cookies.get('shopId');
 
   let token;
   let type;
@@ -29,6 +29,17 @@ export async function middleware(req: NextRequest) {
   if (cookieType) {
     type = cookieType.value;
   }
+
+  const shopIdFromPath = pathname.startsWith('/myshop') ? pathname.split('/myshop/')[1] : null;
+
+  // Check if shopId in the URL matches the cookieShopId
+  if (pathname.startsWith('/myshop') && cookieShopId) {
+    const cookieShopIdValue = cookieShopId.value;
+    if (shopIdFromPath !== cookieShopIdValue) {
+      return NextResponse.redirect(new URL(`/myshop/${cookieShopIdValue}`, req.url));
+    }
+  }
+
   if (type !== 'employer') {
     if (pathname.startsWith('/assignmyshop')) {
       return NextResponse.redirect(new URL('/', req.url));


### PR DESCRIPTION
## 💻 작업 내용

- 내 가게, 내 프로필 페이지에서 params를 제거한 주소로 이동했을때 404 페이지가 뜨거나 해당 정보가 뜨지않는 이슈가 발생
- 기존에는 페이지에서 리다이렉션 처리를 했지만 middleware.ts 파일에서 처리
- 페이지 단위의 리다이렉션 로직을 제거, 프로젝트 파일 수를 줄이고 가독성을 높임.
- 또한 이미지 최적화를 재설정 (webp -> avif), (resize 재설정)
- 1. div의 image background
![이전 이미지 1](https://github.com/user-attachments/assets/b0423754-3916-48e3-9a8e-874d4f41b1db)
- 2. next/image webp (기본 설정)
![최적화 후 이미지 1](https://github.com/user-attachments/assets/d2796a2a-c2d2-4265-a05e-898fba49e0c2)
- 3. next/image avif (추가 설정)
![image](https://github.com/user-attachments/assets/195190c6-2c8d-4bdf-9879-f91be62ab79e)


## 🖼️ 스크린샷
[페이지 리다이렉션 리팩토링 노션 정리](https://quilled-cricket-969.notion.site/2aaff20c496a4ada8b5f2ecb0a68c1d8?pvs=74)
[이미지 최적화 노션정리](https://quilled-cricket-969.notion.site/next-image-865b57f053864034b86dfef1340b823a?pvs=74)


## 🚨 관련 이슈 및 참고 사항

- 배포환경에서 한번 더 확인해볼 예정.
